### PR TITLE
fix: update repo gob hash if git config mailmap content changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,11 +586,8 @@ different names?
 
 Git already has a solution for his problem called [Git
 mailmap](https://git-scm.com/docs/gitmailmap). If a `.mailmap` file is present
-in a Git repository, `git who` will respect it.
-
-Note that `git who` will _not_ consult your Git configuration to find your
-mailmap file if you have configured a different location for it other than the
-conventional `.mailmap` at the root of your repository.
+in a Git repository, or other configuration options are set, `git who` will
+respect it.
 
 ## Git Blame Ignore Revs
 If you have a `.git-blame-ignore-revs` file at the root of your repository,

--- a/cache.go
+++ b/cache.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,7 +19,12 @@ func warnFail(cb cache.Backend, err error) cache.Cache {
 	return cache.NewCache(cb)
 }
 
-func getCache(gitRootPath string, repoFiles git.RepoConfigFiles) cache.Cache {
+// getCache returns the repository's cache.
+func getCache(
+	ctx context.Context,
+	gitRootPath string,
+	repoFiles git.RepoConfigFiles,
+) cache.Cache {
 	var fallback cache.Backend = cacheBackends.NoopBackend{}
 
 	if !cache.IsCachingEnabled() {
@@ -38,7 +44,7 @@ func getCache(gitRootPath string, repoFiles git.RepoConfigFiles) cache.Cache {
 		return warnFail(fallback, err)
 	}
 
-	filename, err := cacheBackends.GobCacheFilename(repoFiles)
+	filename, err := cacheBackends.GobCacheFilename(ctx, repoFiles)
 	if err != nil {
 		return warnFail(fallback, err)
 	}

--- a/dump.go
+++ b/dump.go
@@ -62,7 +62,7 @@ func dump(
 		return err
 	}
 
-	repoFiles, err := git.CheckRepoConfigFiles(gitRootPath)
+	_, err = git.CheckRepoConfigFiles(gitRootPath)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,6 @@ func dump(
 		pathspecs,
 		filters,
 		!short,
-		repoFiles.HasMailmap(),
 	)
 	if err != nil {
 		return err

--- a/hist.go
+++ b/hist.go
@@ -101,7 +101,7 @@ func hist(
 			repoFiles,
 			tallyOpts,
 			end,
-			getCache(gitRootPath, repoFiles),
+			getCache(ctx, gitRootPath, repoFiles),
 			pretty.AllowDynamic(os.Stdout),
 		)
 		if err != nil {

--- a/internal/cache/backends/gob.go
+++ b/internal/cache/backends/gob.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/binary"
 	"encoding/gob"
 	"errors"
@@ -312,8 +313,12 @@ func GobCacheDir(prefix string, gitRootPath string) string {
 	return repoDir
 }
 
-func GobCacheFilename(repoFiles git.RepoConfigFiles) (string, error) {
-	stateHash, err := cache.RepoStateHash(repoFiles)
+// GobCacheFilename gets the filename of the current repository state cache.
+func GobCacheFilename(
+	ctx context.Context,
+	repoFiles git.RepoConfigFiles,
+) (string, error) {
+	stateHash, err := cache.RepoStateHash(ctx, repoFiles)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -2,6 +2,7 @@
 package cache
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"hash/fnv"
@@ -194,10 +195,14 @@ func CacheStorageDir(name string) (_ string, err error) {
 	return absP, nil
 }
 
-// Hash of all the state in the repo that affects the validity of our cache
-func RepoStateHash(rf git.RepoConfigFiles) (string, error) {
+// RepoStateHash hashes the state of configurations that can affect the validity
+// of our cache.
+func RepoStateHash(
+	ctx context.Context,
+	rf git.RepoConfigFiles,
+) (string, error) {
 	h := fnv.New32()
-	err := rf.MailmapHash(h)
+	err := MailmapHash(ctx, h, rf)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cache/hash.go
+++ b/internal/cache/hash.go
@@ -1,0 +1,115 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"io/fs"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/sinclairtarget/git-who/internal/git"
+)
+
+// MailmapHash adds content from configured mailmaps to a repository hash value.
+func MailmapHash(
+	ctx context.Context,
+	h hash.Hash32,
+	rf git.RepoConfigFiles,
+) error {
+	if rf.HasMailmap() {
+		f, err := os.Open(rf.MailmapPath)
+		if !errors.Is(err, fs.ErrNotExist) {
+			if err != nil {
+				return fmt.Errorf("could not read repo mailmap file: %w", err)
+			}
+			defer f.Close()
+			_, err := io.Copy(h, f)
+			if err != nil {
+				return fmt.Errorf("error hashing repo mailmap file: %w", err)
+			}
+		}
+	}
+
+	configMailmapFile := ""
+	configMailmapFileResponse, err := git.RunConfig(ctx, "mailmap.file")
+	if err != nil {
+		return fmt.Errorf("error running config mailmap file command: %w", err)
+	}
+	out, err := configMailmapFileResponse.Stdout()
+	if err != nil {
+		return fmt.Errorf("error parsing config mailmap file command: %w", err)
+	} else {
+		configMailmapFile = out.Stdout
+	}
+	if configMailmapFile != "" {
+		if strings.HasPrefix(configMailmapFile, "~") {
+			usr, err := user.Current()
+			if err != nil {
+				return fmt.Errorf("could not make mailmap file path: %w", err)
+			}
+			configMailmapFile = filepath.Join(usr.HomeDir, configMailmapFile[1:])
+		}
+		f, err := os.Open(configMailmapFile)
+		if !errors.Is(err, os.ErrNotExist) {
+			if err != nil {
+				return fmt.Errorf("could not read config mailmap file: %w", err)
+			}
+			defer f.Close()
+			_, err = io.Copy(h, f)
+			if err != nil {
+				return fmt.Errorf("error hashing config mailmap file: %w", err)
+			}
+		}
+	}
+
+	configMailmapBlob := ""
+	configMailmapBlobResponse, err := git.RunConfig(ctx, "mailmap.blob")
+	if err != nil {
+		return fmt.Errorf("error running config mailmap blob command: %w", err)
+	}
+	out, err = configMailmapBlobResponse.Stdout()
+	if err != nil {
+		return fmt.Errorf("error parsing config mailmap blob command: %w", err)
+	} else {
+		configMailmapBlob = out.Stdout
+	}
+	if strings.Contains(configMailmapBlob, ":") {
+		blobs := []string{
+			configMailmapBlob,
+		}
+		revision, err := git.RunRevParse(ctx, blobs)
+		if err != nil {
+			return fmt.Errorf("error running revision parse command: %w", err)
+		}
+		out, err := revision.Stdout()
+		if err != nil {
+			return fmt.Errorf("could not resolve config mailmap blob: %w", err)
+		}
+		if out.ExitCode != 0 {
+			configMailmapBlob = ""
+		} else {
+			configMailmapBlob = out.Stdout
+		}
+	}
+	if configMailmapBlob != "" {
+		response, err := git.RunCatFile(ctx, configMailmapBlob)
+		if err != nil {
+			return fmt.Errorf("could not read config mailmap blob: %w", err)
+		}
+		out, err := response.Stdout()
+		if err != nil {
+			return fmt.Errorf("error parsing config mailmap blob: %w", err)
+		}
+		contents := out.Stdout
+		if _, err := h.Write([]byte(contents)); err != nil {
+			return fmt.Errorf("error hashing config mailmap blob: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/cache/hash_test.go
+++ b/internal/cache/hash_test.go
@@ -1,0 +1,192 @@
+package cache_test
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/sinclairtarget/git-who/internal/cache"
+	"github.com/sinclairtarget/git-who/internal/git"
+	"github.com/sinclairtarget/git-who/internal/repotest"
+)
+
+func TestMailmapHash(t *testing.T) {
+	tests := map[string]struct {
+		repoMailmapFilePath      string
+		repoMailmapFileContent   string
+		configMailmapFilePath    string
+		configMailmapFileContent string
+		configMailmapBlobPath    string
+		configMailmapBlobContent string
+		expectedHash             uint32
+		expectedError            error
+	}{
+		"none mailmap": {
+			expectedHash: fnv.New32().Sum32(),
+		},
+		"miss mailmap": {
+			repoMailmapFilePath:   ".mailmap",
+			configMailmapFilePath: ".contacts",
+			configMailmapBlobPath: ".rolodex",
+			expectedHash:          fnv.New32().Sum32(),
+		},
+		"repo mailmap": {
+			repoMailmapFilePath:    ".mailmap",
+			repoMailmapFileContent: "Alice <alice@mail.com>",
+			expectedHash:           1682318899,
+		},
+		"file mailmap": {
+			configMailmapFilePath:    ".contacts",
+			configMailmapFileContent: "Bob <bob@mail.com>",
+			expectedHash:             3288519805,
+		},
+		"blob mailmap": {
+			configMailmapBlobPath:    ".rolodex",
+			configMailmapBlobContent: "Chris <chris@mail.com>",
+			expectedHash:             2428936825,
+		},
+		"join mailmap": {
+			repoMailmapFilePath:      ".mailmap",
+			repoMailmapFileContent:   "Alice <alice@mail.com>",
+			configMailmapFilePath:    ".contacts",
+			configMailmapFileContent: "Bob <bob@mail.com>",
+			configMailmapBlobPath:    ".rolodex",
+			configMailmapBlobContent: "Chris <chris@mail.com>",
+			expectedHash:             419655903,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			config, err := repotest.GitConfigPath()
+			if err != nil {
+				t.Fatalf("failed to get config path: %v", err)
+			}
+			original, err := os.ReadFile(config)
+			if err != nil {
+				t.Fatalf("failed to read config file: %v", err)
+			}
+			defer func() {
+				err := os.WriteFile(config, original, 0o644)
+				if err != nil {
+					t.Fatalf("failed to restore .git/config: %v", err)
+				}
+			}()
+			if test.repoMailmapFileContent != "" && test.repoMailmapFilePath != "" {
+				err := os.WriteFile(
+					test.repoMailmapFilePath,
+					[]byte(test.repoMailmapFileContent),
+					0o644,
+				)
+				if err != nil {
+					t.Fatalf("failed to write %s: %v", test.repoMailmapFilePath, err)
+				}
+				defer func() {
+					err := os.Remove(test.repoMailmapFilePath)
+					if err != nil {
+						t.Fatalf("failed to remove %s: %v", test.repoMailmapFilePath, err)
+					}
+				}()
+			}
+			if test.configMailmapFileContent != "" && test.configMailmapFilePath != "" {
+				err := os.WriteFile(
+					test.configMailmapFilePath,
+					[]byte(test.configMailmapFileContent),
+					0o644,
+				)
+				if err != nil {
+					t.Fatalf("failed to write %s: %v", test.configMailmapFilePath, err)
+				}
+				defer func() {
+					err := os.Remove(test.configMailmapFilePath)
+					if err != nil {
+						t.Fatalf("failed to remove %s: %v", test.configMailmapFilePath, err)
+					}
+				}()
+			}
+			if test.configMailmapFilePath != "" {
+				args := []string{
+					"config",
+					"--local",
+					"mailmap.file",
+					test.configMailmapFilePath,
+				}
+				cmd := exec.Command("git", args...)
+				err := cmd.Run()
+				if err != nil {
+					t.Fatalf("failed to set git %v: %v", args, err)
+				}
+			}
+			if test.configMailmapBlobContent != "" && test.configMailmapBlobPath != "" {
+				err = os.WriteFile(
+					test.configMailmapBlobPath,
+					[]byte(test.configMailmapBlobContent),
+					0o644,
+				)
+				if err != nil {
+					t.Fatalf("failed to write %s: %v", test.configMailmapBlobPath, err)
+				}
+				defer func() {
+					err := os.Remove(test.configMailmapBlobPath)
+					if err != nil {
+						t.Fatalf("failed to remove %s: %v", test.configMailmapBlobPath, err)
+					}
+				}()
+			}
+			if test.configMailmapBlobPath != "" {
+				args := []string{
+					"config",
+					"--local",
+					"mailmap.blob",
+					fmt.Sprintf(":0:%s", test.configMailmapBlobPath),
+				}
+				cmd := exec.Command("git", args...)
+				err := cmd.Run()
+				if err != nil {
+					t.Fatalf("failed to set git %v: %v", args, err)
+				}
+			}
+			if test.configMailmapBlobContent != "" && test.configMailmapBlobPath != "" {
+				args := []string{
+					"add",
+					test.configMailmapBlobPath,
+				}
+				cmd := exec.Command("git", args...)
+				err := cmd.Run()
+				if err != nil {
+					t.Fatalf("failed to stage %v: %v", test.configMailmapBlobPath, err)
+				}
+				defer func() {
+					args := []string{
+						"restore",
+						"--staged",
+						test.configMailmapBlobPath,
+					}
+					cmd := exec.Command("git", args...)
+					err := cmd.Run()
+					if err != nil {
+						t.Fatalf("failed to unstage %v: %v", test.configMailmapBlobPath, err)
+					}
+				}()
+			}
+			ctx := context.Background()
+			h := fnv.New32()
+			rf := git.RepoConfigFiles{
+				MailmapPath: test.repoMailmapFilePath,
+			}
+			err = cache.MailmapHash(ctx, h, rf)
+			if err != nil {
+				t.Errorf("got error: %v", err)
+			}
+			if h.Sum32() != test.expectedHash {
+				t.Errorf(
+					"expected %v as hash but got %v",
+					test.expectedHash,
+					h.Sum32(),
+				)
+			}
+		})
+	}
+}

--- a/internal/cache/main_test.go
+++ b/internal/cache/main_test.go
@@ -1,0 +1,19 @@
+package cache_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/sinclairtarget/git-who/internal/repotest"
+)
+
+// Run these tests in the test submodule.
+func TestMain(m *testing.M) {
+	err := repotest.UseTestRepo()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	m.Run()
+}

--- a/internal/concurrent/concurrent.go
+++ b/internal/concurrent/concurrent.go
@@ -57,7 +57,6 @@ type whoperation[T combinable[T]] struct {
 	revspec    []string
 	pathspecs  []string
 	filters    git.LogFilters
-	useMailmap bool
 	ignoreRevs []string
 	tally      tallyFunc[T]
 	opts       tally.TallyOpts
@@ -331,7 +330,6 @@ func TallyCommits(
 		revspec:    revspec,
 		pathspecs:  pathspecs,
 		filters:    filters,
-		useMailmap: repoFiles.HasMailmap(),
 		ignoreRevs: ignoreRevs,
 		tally:      tally.TallyCommitsByPath,
 		opts:       opts,
@@ -371,7 +369,6 @@ func TallyCommitsTree(
 		revspec:    revspec,
 		pathspecs:  pathspecs,
 		filters:    filters,
-		useMailmap: repoFiles.HasMailmap(),
 		ignoreRevs: ignoreRevs,
 		tally:      tally.TallyCommitsByPath,
 		opts:       opts,
@@ -421,7 +418,6 @@ func TallyCommitsTimeline(
 		revspec:    revspec,
 		pathspecs:  pathspecs,
 		filters:    filters,
-		useMailmap: repoFiles.HasMailmap(),
 		ignoreRevs: ignoreRevs,
 		tally:      f,
 		opts:       opts,

--- a/internal/concurrent/worker.go
+++ b/internal/concurrent/worker.go
@@ -191,7 +191,6 @@ loop:
 				ctx,
 				nopaths,
 				true,
-				whop.useMailmap,
 			)
 			if err != nil {
 				return err

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -88,7 +88,6 @@ func CommitsWithOpts(
 		pathspecs,
 		filters,
 		populateDiffs,
-		repoFiles.HasMailmap(),
 	)
 	if err != nil {
 		return nil, nil, err

--- a/internal/repotest/repotest.go
+++ b/internal/repotest/repotest.go
@@ -4,6 +4,8 @@ package repotest
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 const msg = `error changing working directory to submodule: %w
@@ -16,4 +18,29 @@ func UseTestRepo() error {
 	}
 
 	return nil
+}
+
+// GitConfigPath returns the git config file path for testing.
+func GitConfigPath() (string, error) {
+	info, err := os.Stat(".git")
+	if err != nil {
+		return "", fmt.Errorf("failed to stat .git: %w", err)
+	}
+	if info.IsDir() {
+		return filepath.Abs(filepath.Join(".git", "config"))
+	}
+	submodule, err := os.ReadFile(".git")
+	if err != nil {
+		return "", fmt.Errorf("cannot read .git file: %w", err)
+	}
+	text := strings.TrimSpace(string(submodule))
+	prefix := "gitdir: "
+	if !strings.HasPrefix(text, prefix) {
+		return "", fmt.Errorf("failed to find submodule config")
+	}
+	gitdir := strings.TrimSpace(strings.TrimPrefix(text, prefix))
+	if !filepath.IsAbs(gitdir) {
+		gitdir = filepath.Join(filepath.Dir(".git"), gitdir)
+	}
+	return filepath.Join(gitdir, "config"), nil
 }

--- a/table.go
+++ b/table.go
@@ -115,7 +115,7 @@ func table(
 			filters,
 			repoFiles,
 			tallyOpts,
-			getCache(gitRootPath, repoFiles),
+			getCache(ctx, gitRootPath, repoFiles),
 			pretty.AllowDynamic(os.Stdout),
 		)
 		if err != nil {

--- a/tree.go
+++ b/tree.go
@@ -126,7 +126,7 @@ func tree(
 			tallyOpts,
 			wtreeset,
 			gitRootPath,
-			getCache(gitRootPath, repoFiles),
+			getCache(ctx, gitRootPath, repoFiles),
 			pretty.AllowDynamic(os.Stdout),
 		)
 


### PR DESCRIPTION
### Summary

👋 This PR updates the gob hash in cache for a repository if the Git configuration `mailmap` setting is changed.

Fixes an issue where updates to these configurations were not detected and caused the cache to become stale.

### Reviewers

These changes can be tested with either local or global configurations and this branch to confirm the author matches the most recent changes to the mailmap:

```sh
$ git clone https://github.com/zimeg/git-who
$ git checkout fix-mailmap-hash
$ go build
$ ./git-who -v -l
...
level=DEBUG msg="running subprocess" package=git cmd="git config --get mailmap.file"
level=DEBUG msg="subprocess exited" package=git code=0
level=DEBUG msg="running subprocess" package=git cmd="git config --get mailmap.blob"
level=DEBUG msg="subprocess exited" package=git code=1
level=DEBUG msg="cache initialized" package=main path=~/.cache/git-who/gob/git-who-1013de4e/811c9dc5.gobs
$ echo "Eden Zimbelman <zim@o526.net>" > .mailmap
$ ./git-who -v -l
...
level=DEBUG msg="cache initialized" package=main path=~/.cache/git-who/gob/git-who-1013de4e/fcecb5a7.gobs
$ rm .mailmap
$ echo "eden <zim@o526.net>" > .rolodex
$ git config --local mailmap.file $(pwd)/.rolodex
$ ./git-who -v -l
...
level=DEBUG msg="cache initialized" package=main path=~/.cache/git-who/gob/git-who-1013de4e/54d15544.gobs
$ git config --unset --local mailmap.file
$ git config --local mailmap.blob :0:.rolodex
$ ./git-who -v -l
...
level=DEBUG msg="running subprocess" package=git cmd="git config --get mailmap.blob"
level=DEBUG msg="subprocess exited" package=git code=0
level=DEBUG msg="running subprocess" package=git cmd="git rev-parse --no-flags :0:.rolodex"
level=DEBUG msg="subprocess exited" package=git code=128
level=DEBUG msg="cache initialized" package=main path=~/.cache/git-who/gob/git-who-1013de4e/811c9dc5.gobs
$ git add .rolodex
$ ./git-who -v -l
...
level=DEBUG msg="running subprocess" package=git cmd="git rev-parse --no-flags :0:.rolodex"
level=DEBUG msg="subprocess exited" package=git code=0
level=DEBUG msg="running subprocess" package=git cmd="git cat-file blob f6cd90c45d9bd967e618e991f38737f2143ef637"
level=DEBUG msg="subprocess exited" package=git code=0
level=DEBUG msg="cache initialized" package=main path=~/.cache/git-who/gob/git-who-1013de4e/16ef5e3a.gobs
$ git restore --staged .rolodex
$ rm .rolodex
$ git config --unset --local mailmap.blob
```

These changes were tested with the following `git` version:

```sh
$ git --version
git version 2.49.0
```

### Notes

The `log` format used before these changes respects `.mailmap` and seems to also find Git configurations, even if `--no-mailmap` is set:

https://github.com/sinclairtarget/git-who/blob/ae3a23c27f8ee23446001ad8c5df51b2fd0e50c7/internal/git/cmd.go#L17-L18

- https://git-scm.com/docs/git-log#Documentation/git-log.txt-emaNem
- https://git-scm.com/docs/git-log#Documentation/git-log.txt-emaEem
- https://git-scm.com/docs/gitmailmap

Also interesting to note is that multiple formats for mailmap can be used at the same time! 📚 ✨ 