### PR TITLE
add NO_COLOR env variable to avoid ansi escape codes

### DIFF
--- a/internal/pretty/ansi.go
+++ b/internal/pretty/ansi.go
@@ -1,13 +1,72 @@
 // ANSI escape codes
 package pretty
 
-const Reset string = "\x1b[0m"
+var colorEnabled = true
 
-const Green string = "\x1b[32m"
-const Red string = "\x1b[31m"
-const DefaultColor string = "\x1b[39m"
+// SetColorEnabled controls whether ANSI color codes are output
+func SetColorEnabled(enabled bool) {
+	colorEnabled = enabled
+}
 
-const Dim string = "\x1b[2m"
-const Invert string = "\x1b[7m"
+// GetColorEnabled returns whether ANSI color codes are currently enabled
+func GetColorEnabled() bool {
+	return colorEnabled
+}
 
+const resetCode string = "\x1b[0m"
+const greenCode string = "\x1b[32m"
+const redCode string = "\x1b[31m"
+const defaultColorCode string = "\x1b[39m"
+const dimCode string = "\x1b[2m"
+const invertCode string = "\x1b[7m"
+
+// Reset returns the reset ANSI code if colors are enabled, empty string otherwise
+func Reset() string {
+	if colorEnabled {
+		return resetCode
+	}
+	return ""
+}
+
+// Green returns the green ANSI code if colors are enabled, empty string otherwise
+func Green() string {
+	if colorEnabled {
+		return greenCode
+	}
+	return ""
+}
+
+// Red returns the red ANSI code if colors are enabled, empty string otherwise
+func Red() string {
+	if colorEnabled {
+		return redCode
+	}
+	return ""
+}
+
+// DefaultColor returns the default color ANSI code if colors are enabled, empty string otherwise
+func DefaultColor() string {
+	if colorEnabled {
+		return defaultColorCode
+	}
+	return ""
+}
+
+// Dim returns the dim ANSI code if colors are enabled, empty string otherwise
+func Dim() string {
+	if colorEnabled {
+		return dimCode
+	}
+	return ""
+}
+
+// Invert returns the invert ANSI code if colors are enabled, empty string otherwise
+func Invert() string {
+	if colorEnabled {
+		return invertCode
+	}
+	return ""
+}
+
+// EraseLine always returns the erase line code as it's used for progress indicators
 const EraseLine string = "\x1b[2K"

--- a/internal/subcommands/hist.go
+++ b/internal/subcommands/hist.go
@@ -184,10 +184,10 @@ func drawPlot(
 				"%s ┤ %s%s%-*s%s  %s\n",
 				bucket.Name,
 				valueBar,
-				pretty.Dim,
+				pretty.Dim(),
 				barWidth-clampedValue,
 				totalBar,
-				pretty.Reset,
+				pretty.Reset(),
 				tallyPart,
 			)
 
@@ -213,12 +213,12 @@ func fmtHistTally(
 	case tally.LinesMode:
 		metric = fmt.Sprintf(
 			"(%s%s%s / %s%s%s)",
-			pretty.Green,
+			pretty.Green(),
 			format.Number(t.LinesAdded),
-			pretty.DefaultColor,
-			pretty.Red,
+			pretty.DefaultColor(),
+			pretty.Red(),
 			format.Number(t.LinesRemoved),
-			pretty.DefaultColor,
+			pretty.DefaultColor(),
 		)
 	default:
 		panic("unrecognized tally mode in switch")
@@ -234,10 +234,10 @@ func fmtHistTally(
 	if fade {
 		return fmt.Sprintf(
 			"%s%s %s%s",
-			pretty.Dim,
+			pretty.Dim(),
 			author,
 			metric,
-			pretty.Reset,
+			pretty.Reset(),
 		)
 	} else {
 		return fmt.Sprintf("%s %s", author, metric)

--- a/internal/subcommands/table.go
+++ b/internal/subcommands/table.go
@@ -314,17 +314,17 @@ func writeTable(
 	for i, t := range tallies {
 		alternating := ""
 		if totalRows > maxBeforeColorAlternating && i%2 == 1 {
-			alternating = pretty.Invert
+			alternating = pretty.Invert()
 		}
 
 		lines := fmt.Sprintf(
 			"%s%7s%s / %s%7s%s",
-			pretty.Green,
+			pretty.Green(),
 			format.Number(t.LinesAdded),
-			pretty.DefaultColor,
-			pretty.Red,
+			pretty.DefaultColor(),
+			pretty.Red(),
 			format.Number(t.LinesRemoved),
-			pretty.DefaultColor,
+			pretty.DefaultColor(),
 		)
 
 		if mode == tally.LinesMode || mode == tally.FilesMode {
@@ -336,7 +336,7 @@ func writeTable(
 				format.Number(t.Commits),
 				format.Number(t.FileCount),
 				lines,
-				pretty.Reset,
+				pretty.Reset(),
 			)
 		} else if mode == tally.FirstModifiedMode {
 			fmt.Printf(
@@ -345,7 +345,7 @@ func writeTable(
 				formatAuthor(t, showEmail, colwidth-22),
 				format.RelativeTime(progStart, t.FirstCommitTime),
 				format.Number(t.Commits),
-				pretty.Reset,
+				pretty.Reset(),
 			)
 		} else {
 			fmt.Printf(
@@ -354,7 +354,7 @@ func writeTable(
 				formatAuthor(t, showEmail, colwidth-22),
 				format.RelativeTime(progStart, t.LastCommitTime),
 				format.Number(t.Commits),
-				pretty.Reset,
+				pretty.Reset(),
 			)
 		}
 	}

--- a/internal/subcommands/tree.go
+++ b/internal/subcommands/tree.go
@@ -315,12 +315,12 @@ func fmtTallyMetric(t tally.FinalTally, opts printTreeOpts) string {
 	case tally.LinesMode:
 		return fmt.Sprintf(
 			"(%s%s%s / %s%s%s)",
-			pretty.Green,
+			pretty.Green(),
 			format.Number(t.LinesAdded),
-			pretty.DefaultColor,
-			pretty.Red,
+			pretty.DefaultColor(),
+			pretty.Red(),
 			format.Number(t.LinesRemoved),
-			pretty.DefaultColor,
+			pretty.DefaultColor(),
 		)
 	case tally.LastModifiedMode:
 		return fmt.Sprintf(
@@ -356,7 +356,7 @@ func printTree(lines []treeOutputLine, showEmail bool) {
 
 		var path string
 		if line.dimPath {
-			path = fmt.Sprintf("%s%s%s", pretty.Dim, line.path, pretty.Reset)
+			path = fmt.Sprintf("%s%s%s", pretty.Dim(), line.path, pretty.Reset())
 		} else {
 			path = line.path
 		}
@@ -382,9 +382,9 @@ func printTree(lines []treeOutputLine, showEmail bool) {
 				"%s%s%s%s%s%s %s\n",
 				line.indent,
 				path,
-				pretty.Dim,
+				pretty.Dim(),
 				separator,
-				pretty.Reset,
+				pretty.Reset(),
 				author,
 				line.metric,
 			)
@@ -393,11 +393,11 @@ func printTree(lines []treeOutputLine, showEmail bool) {
 				"%s%s%s%s%s %s%s\n",
 				line.indent,
 				path,
-				pretty.Dim,
+				pretty.Dim(),
 				separator,
 				author,
 				line.metric,
-				pretty.Reset,
+				pretty.Reset(),
 			)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/sinclairtarget/git-who/internal/git"
+	"github.com/sinclairtarget/git-who/internal/pretty"
 	"github.com/sinclairtarget/git-who/internal/subcommands"
 	"github.com/sinclairtarget/git-who/internal/tally"
 	"github.com/sinclairtarget/git-who/internal/utils/flagutils"
@@ -40,6 +41,7 @@ func main() {
 
 	versionFlag := mainFlagSet.Bool("version", false, "Print version and exit")
 	verboseFlag := mainFlagSet.Bool("v", false, "Enables debug logging")
+	colorFlag := mainFlagSet.Bool("color", false, "Force enable ANSI color output (overrides NO_COLOR env var)")
 
 	mainFlagSet.Usage = func() {
 		fmt.Println("Usage: git-who [-v] [subcommand] [subcommand options...]")
@@ -71,7 +73,7 @@ func main() {
 loop:
 	for subcmdIndex < len(os.Args) {
 		switch os.Args[subcmdIndex] {
-		case "-version", "--version", "-v", "--v", "-h", "--help":
+		case "-version", "--version", "-v", "--v", "-h", "--help", "-color", "--color":
 			subcmdIndex += 1
 		default:
 			break loop
@@ -83,6 +85,14 @@ loop:
 	if *versionFlag {
 		fmt.Printf("%s %s\n", Version, Commit)
 		return
+	}
+
+	// Handle color settings according to NO_COLOR spec
+	// Priority: --color flag > NO_COLOR env var > default (enabled)
+	if *colorFlag {
+		pretty.SetColorEnabled(true)
+	} else if noColor, exists := os.LookupEnv("NO_COLOR"); exists && noColor != "" {
+		pretty.SetColorEnabled(false)
 	}
 
 	if *verboseFlag {


### PR DESCRIPTION
Sometimes ansi escape codes cannot be rendered (e.g. when executing
inside of vim with `:!git who -l`), so add a evironment flag which
doesn't print ansi escape codes. Also add the --color flag to override
the environment variable.