### PR TITLE
Fix formatting for Mac OS installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [releases](https://github.com/sinclairtarget/git-who/releases).
 
 #### Mac OS
 ```
-$ brew install git-who
+brew install git-who
 ```
 
 ### Docker


### PR DESCRIPTION
When I click the copy button, it was including the `$` at the beginning of the command.