### PR TITLE
Fix LimitDiffsByPathspec to handle exclusion-only pathspecs

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -243,7 +243,7 @@ func LimitDiffsByPathspec(
 		for commit := range commits {
 			filtered := []FileDiff{}
 			for _, diff := range commit.FileDiffs {
-				shouldInclude := false
+				shouldInclude := len(includes) == 0
 				for _, p := range includes {
 					if PathspecMatch(p, diff.Path) {
 						shouldInclude = true


### PR DESCRIPTION
## Description

When using only exclusion pathspecs (e.g., `git who table -f -n 0 ':!*.json'`), the Files and Lines (+/-) columns show 0 values. This happens because the concurrent execution path post-filters diffs using `LimitDiffsByPathspec()`, which incorrectly initializes `shouldInclude` to `false` when no include pathspecs are present.

## Root Cause

In `internal/git/git.go`, the `LimitDiffsByPathspec` function splits pathspecs into includes and excludes. When only `:!*.json` is provided:
- `includes = []` (empty)
- `excludes = ["*.json"]`

The initialization `shouldInclude := false` means every file diff is rejected since the loop over the empty `includes` slice never executes.

## Fix

Changed `shouldInclude := false` to `shouldInclude := len(includes) == 0`.

This ensures that when only exclusion pathspecs are provided, all files are included by default and only removed if they match an exclusion pattern. Mixed include/exclude cases continue to work as before.

## Testing

- Verified on `rubengmurray/no-unawaited-dot-catch-throw`: `git who table -f -n 0 ':!*.json'` now correctly shows 9 files, 568/120 lines instead of 0/0
- Both concurrent (`GOMAXPROCS=4`) and non-concurrent (`GOMAXPROCS=1`) paths produce identical correct results
- Multiple exclusion patterns work correctly
- All unit tests pass:
  ```
  ok  github.com/sinclairtarget/git-who/internal/git    0.792s
  ok  github.com/sinclairtarget/git-who/internal/tally   1.377s
  ok  github.com/sinclairtarget/git-who/internal/format  0.660s
  ```